### PR TITLE
Fixed build errors on Mac OS X with clang3.8 and MacPorts Python 2.7

### DIFF
--- a/common/cmake/ALPSCommonModuleDefinitions.cmake
+++ b/common/cmake/ALPSCommonModuleDefinitions.cmake
@@ -75,7 +75,7 @@ macro(add_testing)
   option(Testing "Enable testing" ON)
   option(TestXMLOutput "Generate XML-formatted test results" OFF)
   if (Testing)
-    find_file(PYTEST "py.test" DOC "Location of py.test executable")
+    find_file(PYTEST "py.test" PATHS $ENV{PYTEST} DOC "Location of py.test executable")
     if(NOT PYTEST)
       message(SEND_ERROR "
         The testing is enabled,

--- a/utilities/include/alps/python/utilities/pyobj_interface.hpp
+++ b/utilities/include/alps/python/utilities/pyobj_interface.hpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <stdexcept>
+#include <string>
 
 namespace alps {
     namespace python { 


### PR DESCRIPTION
I've fixed some issues to build ALPSCore-Python on my laptop.